### PR TITLE
Resolved Issue "Drivebase SpeedControl function"

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -40,7 +40,7 @@ public class RobotContainer {
             () -> -joystick.getRawAxis(1),
             () -> -joystick.getRawAxis(0),
             () -> -joystick.getRawAxis(2),
-            () -> (joystick.getRawAxis(3) - joystick.getRawAxis(4) + 2d) / 2d + 0.5,
+            () -> (joystick.getRawAxis(3) - joystick.getRawAxis(4)) / 4d + 0.5,
             driveTrain);
     driveTrain.setDefaultCommand(swerveJoystickCommand);
 


### PR DESCRIPTION
As stated in the issue, the swerve drive speed was between the range [0,2.5]. This has now been resolved with this branch where the min value is 0 and the max value is 1. We plotted this on demos to ensure this. The only changes occur in RobotContainer.java.
<img width="1293" alt="Screenshot 2024-01-29 at 9 03 04 PM" src="https://github.com/firebots-software/2024-crescendo/assets/65196684/3a6d5f63-6316-4ed4-b5e5-6cc7348e8beb">
